### PR TITLE
Revert "Update dependency golang-version to v1.22.1"

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -18,5 +18,5 @@ jobs:
   go:
     uses: int128/kubebuilder-workflows/.github/workflows/go.yaml@v1
     with:
-      go-version: 1.22.1
+      go-version: 1.21.7
       golangci-lint-version: v1.57.1

--- a/.github/workflows/scaffold.yaml
+++ b/.github/workflows/scaffold.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.1
+          go-version: 1.21.7
 
       - run: |
           curl -L -o kubebuilder https://github.com/kubernetes-sigs/kubebuilder/releases/download/${KUBEBUILDER_VERSION}/kubebuilder_$(go env GOOS)_$(go env GOARCH)


### PR DESCRIPTION
Reverts int128/kubebuilder-updates#80.

main branch is broken due to Renovate automerge.