### PR TITLE
Exclude .github from scaffold

### DIFF
--- a/.github/workflows/scaffold.yaml
+++ b/.github/workflows/scaffold.yaml
@@ -34,8 +34,8 @@ jobs:
           KUBEBUILDER_VERSION: ${{ steps.kubebuilder-version.outputs.value }}
       - run: chmod +x kubebuilder && mv kubebuilder /usr/local/bin/
 
-      - name: Remove old files
-        run: |
+      # Remove the existing files to avoid kubebuilder error
+      - run: |
           rm -vfr \
             PROJECT \
             api \
@@ -58,5 +58,8 @@ jobs:
       - run: kubebuilder create api --group webapp --version v1 --kind Guestbook --controller --resource
       - run: make test
 
-      - run: git checkout -- e2e_test
+      # Restore the original files
+      - run: rm -vfr .github
+      - run: git checkout -- e2e_test .github
+
       - uses: int128/update-generated-files-action@757376506709ed3d87f14a80ca28a98736d52236 # v2.55.0


### PR DESCRIPTION
As of kubebuilder v4.3.0, it generates `.github/workflows`. It breaks the scaffold workflow. Here is the error log at https://github.com/int128/kubebuilder-updates/commit/5307d332b5156e5c33444da7c535d35d05262bfc.

```console
/usr/bin/git -c http.https://github.com/.extraheader= -c http.https://github.com/.extraheader=AUTHORIZATION: basic *** push origin HEAD:refs/heads/renovate/kubernetes-sigs-kubebuilder-4.x
To https://github.com/int128/kubebuilder-updates
 ! [remote rejected] HEAD -> renovate/kubernetes-sigs-kubebuilder-4.x (refusing to allow a GitHub App to create or update workflow `.github/workflows/lint.yml` without `workflows` permission)
error: failed to push some refs to 'https://github.com/int128/kubebuilder-updates'
Error: Error: The process '/usr/bin/git' failed with exit code 1
```

Pick https://github.com/int128/kubebuilder-updates/pull/139/commits/18c4041c18aa63a651f90acdb4ea11b8f041003c